### PR TITLE
Add vercel team owner support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This plugin solves:
         vercel: {
             token: env('VERCEL_TOKEN'),
             projectId: env('VERCEL_PROJECT_ID'),
+            teamId: env('VERCEL_TEAM_ID'), // optional: if project owner is a team
             triggers: {
                 production: env('VERCEL_TRIGGER_PRODUCTION')
             },

--- a/services/vercel.js
+++ b/services/vercel.js
@@ -43,10 +43,8 @@ module.exports = {
     if (!conf) throw "[strapi-plugin-vercel] Missing vercel.projectId";
     return conf;
   },
-  // optional teamId
   _getApiTeamId() {
-    const conf = strapi.config.server.vercel.teamId;
-    return conf
+    return strapi.config.server.vercel.teamId;
   },
   _getApiTriggers() {
     const conf = strapi.config.server.vercel.triggers;

--- a/services/vercel.js
+++ b/services/vercel.js
@@ -2,7 +2,11 @@ const axios = require("axios");
 
 module.exports = {
   async getDeployments() {
-    const res = await this._getClient().get(`/v6/now/deployments?projectId=${this._getApiProjectId()}&limit=10`);
+    const projectId = this._getApiProjectId();
+    const teamId = this._getApiTeamId();
+    const res = await this._getClient().get(
+      `/v6/now/deployments?projectId=${projectId}&limit=10${teamId ? `&teamId=${teamId}` : ''}`
+    );
     return res.data;
   },
   async getDeployment(id) {
@@ -38,6 +42,11 @@ module.exports = {
     const conf = strapi.config.server.vercel.projectId;
     if (!conf) throw "[strapi-plugin-vercel] Missing vercel.projectId";
     return conf;
+  },
+  // optional teamId
+  _getApiTeamId() {
+    const conf = strapi.config.server.vercel.teamId;
+    return conf
   },
   _getApiTriggers() {
     const conf = strapi.config.server.vercel.triggers;


### PR DESCRIPTION
I have a project that's owned by a team, which is currently not supported by this plugin. 
Added support for the `&teamId=` query param in order to fetch deployments for a team-owned project.